### PR TITLE
fix: Install Node.js dependencies for PyExecJS during Python setup

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -11,10 +11,10 @@ files:
   - '!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}'
 # asarUnpack not needed - Python runtime is in extraResources
 extraResources:
-  # Python scripts
+  # Python scripts and Node.js dependencies (required for PyExecJS)
   - from: "python-engine"
     to: "python-engine"
-    filter: ["**/*", "!__pycache__", "!*.pyc", "!.git"]
+    filter: ["**/*", "!__pycache__", "!*.pyc", "!.git", "!.gitignore", "!.env"]
   # Python packages (pre-installed dependencies)
   - from: "resources/python-packages"
     to: "python-packages"


### PR DESCRIPTION
The python-engine requires Node.js modules (crypto-js, jsdom) for PyExecJS
to execute JavaScript code. This change adds pnpm/npm install step to the
install-python-deps.js script to ensure these dependencies are available
when the application is packaged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 优化了构建配置的资源过滤规则
  * 改进了依赖安装流程，增强了错误处理机制，并添加了依赖预安装步骤

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->