### PR TITLE
fix: macOS Intel / multi-arch better-sqlite3 native binary (#18)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Verify native-arch helpers
+        run: pnpm run test:native-arch
+
       - name: Download Python for x64 (macOS only)
         if: runner.os == 'macOS'
         run: node scripts/download-python.js darwin-x64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes are listed here.
 
 <br>
 
+## [Unreleased]
+
+### Bug Fixes
+
+- Rebuild and verify `better-sqlite3` per target architecture so macOS Intel (x64) / Windows ARM64 packages no longer ship the host-arch native binary (#18)
+
 ## [1.1.3] - 2026-05-31
 
 ### Features

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -73,7 +73,11 @@ linux:
   category: Utility
 appImage:
   artifactName: ${name}-${version}.${ext}
+# Keep false: a single multi-arch pack must not rebuild only for the host.
+# beforePack rebuilds better-sqlite3 per target arch; afterPack verifies it (#18).
 npmRebuild: false
+beforePack: scripts/before-pack.js
+afterPack: scripts/after-pack.js
 publish:
   provider: github
   owner: PeanutSplash

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "cross-env ELECTRON_DISABLE_SANDBOX=1 electron-vite dev -w",
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.tsx --fix",
+    "test:native-arch": "node scripts/native-arch.selftest.js",
     "start": "electron-vite preview",
     "postinstall": "electron-builder install-app-deps",
     "setup:python": "node scripts/download-python.js && node scripts/install-python-deps.js",

--- a/scripts/after-pack.js
+++ b/scripts/after-pack.js
@@ -1,0 +1,49 @@
+'use strict'
+
+/**
+ * Fail packaging if the shipped better-sqlite3 binary does not match the
+ * target architecture (guards against arch contamination across multi-arch builds).
+ */
+
+const {
+  archName,
+  detectBinaryArch,
+  betterSqliteBinaryPath,
+  findResourcesDir
+} = require('./native-arch')
+
+/** @param {import('electron-builder').AfterPackContext} context */
+exports.default = async function afterPack(context) {
+  const expectedArch = archName(context.arch)
+  if (expectedArch === 'universal') {
+    // Universal merges arch-specific apps; per-arch checks already ran.
+    return
+  }
+
+  const resourcesDir = findResourcesDir(context.appOutDir, context.electronPlatformName)
+  if (!resourcesDir) {
+    throw new Error(
+      `[afterPack] Could not locate Resources for ${context.electronPlatformName} in ${context.appOutDir}`
+    )
+  }
+
+  const binaryPath = betterSqliteBinaryPath(resourcesDir)
+  const actualArch = detectBinaryArch(binaryPath, context.electronPlatformName)
+
+  if (!actualArch) {
+    throw new Error(
+      `[afterPack] better-sqlite3 native binary missing or unreadable at:\n  ${binaryPath}`
+    )
+  }
+
+  if (actualArch !== expectedArch) {
+    throw new Error(
+      `[afterPack] FATAL: better-sqlite3 arch mismatch — refusing to ship a broken build.\n` +
+        `  expected: ${expectedArch}\n` +
+        `  actual:   ${actualArch}\n` +
+        `  path:     ${binaryPath}`
+    )
+  }
+
+  console.log(`[afterPack] verified better-sqlite3 is ${actualArch} for ${context.electronPlatformName}`)
+}

--- a/scripts/before-pack.js
+++ b/scripts/before-pack.js
@@ -1,0 +1,33 @@
+'use strict'
+
+/**
+ * Rebuild native modules for the architecture currently being packaged.
+ *
+ * electron-builder with `npmRebuild: false` (required for multi-arch packs)
+ * would otherwise ship the host-arch better-sqlite3 binary into every target
+ * (e.g. arm64 .node inside the Intel x64 .dmg) — see #18.
+ */
+
+const path = require('path')
+const { archName } = require('./native-arch')
+
+/** @param {import('electron-builder').BeforePackContext} context */
+exports.default = async function beforePack(context) {
+  const arch = archName(context.arch)
+  const projectDir = context.packager.projectDir
+  const electronVersion = require(path.join(projectDir, 'node_modules/electron/package.json')).version
+
+  console.log(`[beforePack] Rebuilding better-sqlite3 for ${context.electronPlatformName}-${arch} (electron ${electronVersion})`)
+
+  const { rebuild } = require('@electron/rebuild')
+
+  await rebuild({
+    buildPath: projectDir,
+    electronVersion,
+    arch,
+    force: true,
+    onlyModules: ['better-sqlite3']
+  })
+
+  console.log(`[beforePack] better-sqlite3 rebuild complete for ${arch}`)
+}

--- a/scripts/native-arch.js
+++ b/scripts/native-arch.js
@@ -1,0 +1,129 @@
+'use strict'
+
+const fs = require('fs')
+const { execFileSync } = require('child_process')
+
+/** electron-builder Arch enum → Node arch name */
+const ARCH_NAME = {
+  0: 'ia32',
+  1: 'x64',
+  2: 'armv7l',
+  3: 'arm64',
+  4: 'universal'
+}
+
+/**
+ * @param {number|string} arch
+ * @returns {string}
+ */
+function archName(arch) {
+  if (typeof arch === 'string') return arch
+  const name = ARCH_NAME[arch]
+  if (!name) {
+    throw new Error(`Unknown electron-builder Arch value: ${arch}`)
+  }
+  return name
+}
+
+/**
+ * Detect CPU architecture of a native .node / shared library binary.
+ * @param {string} binaryPath
+ * @param {string} platform electronPlatformName: darwin | win32 | linux
+ * @returns {'x64'|'arm64'|'ia32'|'armv7l'|null}
+ */
+function detectBinaryArch(binaryPath, platform) {
+  if (!fs.existsSync(binaryPath)) return null
+
+  if (platform === 'win32') {
+    const buf = fs.readFileSync(binaryPath)
+    if (buf.length < 0x40 || buf.toString('ascii', 0, 2) !== 'MZ') return null
+    const peOffset = buf.readUInt32LE(0x3c)
+    if (peOffset + 6 > buf.length || buf.toString('ascii', peOffset, peOffset + 4) !== 'PE\0\0') {
+      return null
+    }
+    const machine = buf.readUInt16LE(peOffset + 4)
+    // IMAGE_FILE_MACHINE_*
+    if (machine === 0x8664) return 'x64'
+    if (machine === 0xaa64) return 'arm64'
+    if (machine === 0x014c) return 'ia32'
+    if (machine === 0x01c4) return 'armv7l'
+    return null
+  }
+
+  // Mach-O / ELF — prefer `file` when available (macOS & Linux CI)
+  try {
+    const out = execFileSync('file', ['-b', binaryPath], { encoding: 'utf8' })
+    if (/arm64|aarch64/i.test(out)) return 'arm64'
+    if (/x86[_-]64|x86-64|Mach-O 64-bit.*x86_64/i.test(out)) return 'x64'
+    if (/\barm\b|armv7/i.test(out)) return 'armv7l'
+    if (/\bi386\b|\bx86\b/i.test(out)) return 'ia32'
+  } catch {
+    // fall through to header parse
+  }
+
+  const buf = fs.readFileSync(binaryPath)
+
+  // Mach-O magic
+  if (buf.length >= 8) {
+    const magic = buf.readUInt32LE(0)
+    // MH_MAGIC_64 / MH_CIGAM_64 / FAT
+    if (magic === 0xfeedfacf || magic === 0xcffaedfe) {
+      const cputype = magic === 0xfeedfacf ? buf.readInt32LE(4) : buf.readInt32BE(4)
+      // CPU_TYPE_X86_64 = 0x01000007, CPU_TYPE_ARM64 = 0x0100000c
+      if (cputype === 0x01000007 || cputype === 0x07000001) return 'x64'
+      if (cputype === 0x0100000c || cputype === 0x0c000001) return 'arm64'
+    }
+  }
+
+  // ELF e_machine
+  if (buf.length >= 20 && buf[0] === 0x7f && buf.toString('ascii', 1, 4) === 'ELF') {
+    const little = buf[5] === 1
+    const em = little ? buf.readUInt16LE(18) : buf.readUInt16BE(18)
+    if (em === 62) return 'x64' // EM_X86_64
+    if (em === 183) return 'arm64' // EM_AARCH64
+    if (em === 3) return 'ia32' // EM_386
+    if (em === 40) return 'armv7l' // EM_ARM
+  }
+
+  return null
+}
+
+/**
+ * Locate better_sqlite3.node inside a packaged app resources directory.
+ * @param {string} resourcesDir
+ * @returns {string}
+ */
+function betterSqliteBinaryPath(resourcesDir) {
+  return require('path').join(
+    resourcesDir,
+    'app.asar.unpacked',
+    'node_modules',
+    'better-sqlite3',
+    'build',
+    'Release',
+    'better_sqlite3.node'
+  )
+}
+
+/**
+ * @param {string} appOutDir
+ * @param {string} electronPlatformName
+ * @returns {string|null}
+ */
+function findResourcesDir(appOutDir, electronPlatformName) {
+  const path = require('path')
+  if (electronPlatformName === 'darwin' || electronPlatformName === 'mas') {
+    const entries = fs.readdirSync(appOutDir).filter((name) => name.endsWith('.app'))
+    if (entries.length === 0) return null
+    return path.join(appOutDir, entries[0], 'Contents', 'Resources')
+  }
+  return path.join(appOutDir, 'resources')
+}
+
+module.exports = {
+  ARCH_NAME,
+  archName,
+  detectBinaryArch,
+  betterSqliteBinaryPath,
+  findResourcesDir
+}

--- a/scripts/native-arch.selftest.js
+++ b/scripts/native-arch.selftest.js
@@ -1,0 +1,91 @@
+'use strict'
+
+/**
+ * Lightweight self-check for native-arch helpers (no Electron required).
+ * Run: node scripts/native-arch.selftest.js
+ */
+
+const assert = require('assert')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const { archName, detectBinaryArch } = require('./native-arch')
+
+assert.strictEqual(archName(1), 'x64')
+assert.strictEqual(archName(3), 'arm64')
+assert.strictEqual(archName('x64'), 'x64')
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'native-arch-'))
+
+// Minimal PE (Windows) x64
+{
+  const pe = Buffer.alloc(0x100)
+  pe.write('MZ', 0)
+  pe.writeUInt32LE(0x80, 0x3c)
+  pe.write('PE\0\0', 0x80)
+  pe.writeUInt16LE(0x8664, 0x84) // Machine = AMD64
+  const p = path.join(tmp, 'win-x64.node')
+  fs.writeFileSync(p, pe)
+  assert.strictEqual(detectBinaryArch(p, 'win32'), 'x64')
+}
+
+// Minimal PE ARM64
+{
+  const pe = Buffer.alloc(0x100)
+  pe.write('MZ', 0)
+  pe.writeUInt32LE(0x80, 0x3c)
+  pe.write('PE\0\0', 0x80)
+  pe.writeUInt16LE(0xaa64, 0x84)
+  const p = path.join(tmp, 'win-arm64.node')
+  fs.writeFileSync(p, pe)
+  assert.strictEqual(detectBinaryArch(p, 'win32'), 'arm64')
+}
+
+// Minimal Mach-O 64 little-endian x86_64
+{
+  const macho = Buffer.alloc(32)
+  macho.writeUInt32LE(0xfeedfacf, 0)
+  macho.writeInt32LE(0x01000007, 4) // CPU_TYPE_X86_64
+  const p = path.join(tmp, 'mac-x64.node')
+  fs.writeFileSync(p, macho)
+  assert.strictEqual(detectBinaryArch(p, 'darwin'), 'x64')
+}
+
+// Minimal Mach-O 64 little-endian arm64
+{
+  const macho = Buffer.alloc(32)
+  macho.writeUInt32LE(0xfeedfacf, 0)
+  macho.writeInt32LE(0x0100000c, 4) // CPU_TYPE_ARM64
+  const p = path.join(tmp, 'mac-arm64.node')
+  fs.writeFileSync(p, macho)
+  assert.strictEqual(detectBinaryArch(p, 'darwin'), 'arm64')
+}
+
+// Minimal ELF x86_64
+{
+  const elf = Buffer.alloc(64)
+  elf[0] = 0x7f
+  elf.write('ELF', 1)
+  elf[4] = 2 // 64-bit
+  elf[5] = 1 // little-endian
+  elf.writeUInt16LE(62, 18) // EM_X86_64
+  const p = path.join(tmp, 'linux-x64.node')
+  fs.writeFileSync(p, elf)
+  assert.strictEqual(detectBinaryArch(p, 'linux'), 'x64')
+}
+
+// Minimal ELF aarch64
+{
+  const elf = Buffer.alloc(64)
+  elf[0] = 0x7f
+  elf.write('ELF', 1)
+  elf[4] = 2
+  elf[5] = 1
+  elf.writeUInt16LE(183, 18) // EM_AARCH64
+  const p = path.join(tmp, 'linux-arm64.node')
+  fs.writeFileSync(p, elf)
+  assert.strictEqual(detectBinaryArch(p, 'linux'), 'arm64')
+}
+
+fs.rmSync(tmp, { recursive: true, force: true })
+console.log('native-arch.selftest: ok')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #18 — Intel (x86_64) macOS builds were shipping an **arm64** `better-sqlite3` native binary, so the app crashed on launch with:

`mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64')`

### Cause

`electron-builder` builds both `x64` and `arm64` in one pass with `npmRebuild: false`. Whatever host-arch `.node` was in `node_modules` got packed into **every** installer (same class of bug can hit Windows ARM64).

### Fix

- `beforePack`: rebuild `better-sqlite3` for the **current target arch** via `@electron/rebuild` (uses prebuilds; verified x64↔arm64 swap works)
- `afterPack`: assert the packaged `better_sqlite3.node` matches the target arch (fail the build otherwise)
- CI runs `pnpm test:native-arch` before packaging

### Notes

After merge, cut a new release so updated macOS Intel / Windows ARM64 artifacts are published. Existing v1.1.3 Intel DMG is still broken until then.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cfa8676-09ba-4d0f-a0d9-145f29d69b0d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cfa8676-09ba-4d0f-a0d9-145f29d69b0d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修复 macOS Intel（x64）和 Windows ARM64 安装包中可能包含错误架构原生组件的问题。
  * 构建过程中会自动按目标架构重建并验证数据库原生组件，减少安装后运行失败的情况。

* **测试**
  * 新增构建前的原生架构自检，覆盖 Windows、macOS 和 Linux 架构识别。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->