### PR TITLE
chore: sync python-engine with upstream Spider_XHS alg update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes are listed here.
 
 - Rebuild and verify `better-sqlite3` per target architecture so macOS Intel (x64) / Windows ARM64 packages no longer ship the host-arch native binary (#18)
 
+### Chores
+
+- Sync `python-engine` with upstream `cv-cat/Spider_XHS` algorithm/auth overhaul (`feat: update all alg`); adapt Electron `cli.py` to `XHSPcAuth` + bootstrap, keep poisson request delay
+
 ## [1.1.3] - 2026-05-31
 
 ### Features


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

上游 [cv-cat/Spider_XHS](https://github.com/cv-cat/Spider_XHS) 自上次同步后有实质爬虫更新，其中最关键的是 **#178 `feat: update all alg`**（2026-07-25）：签名/鉴权体系重构为 `xhs_utils/xhs_core` + `XHSPcAuth`，并更新全部 PC/Creator API。

`PeanutSplash/Spider_XHS` fork 此前与上游 diverge（ahead 16 / behind 49），`merge-upstream` 因冲突失败。本次已在 fork 上手动合并并推送 `master`（`266135b`），再 bump 本仓库 submodule。

### 同步内容（爬虫相关）

- 新算法运行时：`xhs_utils/xhs_core/**`、`xhs_utils/xhs_pc/**`、`xhs_utils/xhs_creator/**`
- API 全面更新：`apis/xhs_*.py`
- `Data_Spider` 迁至 `spider/spider.py`，通过 `XHSPcAuth` 持有 Cookie/签名状态
- 依赖新增 `curl_cffi==0.15.0`；Node 侧仅保留 `crypto-js`

### 桌面端适配（保留在 fork）

- 更新 `cli.py`：`XHSPcAuth.from_cookie` + `bootstrap`，去掉旧的 `cookies_str` 入参
- 保留泊松请求间隔（`REQUEST_DELAY_MS`）
- `spider_some_note` 继续 `return note_list`，保证 Electron 任务 `count`

### 风险

- 签名链路变化较大，建议用真实 Cookie 跑一遍搜索 / 用户 / 笔记任务再发版
- `curl_cffi` 需随 `setup:python` 重新安装到 `resources/python-packages`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cfa8676-09ba-4d0f-a0d9-145f29d69b0d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cfa8676-09ba-4d0f-a0d9-145f29d69b0d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

